### PR TITLE
Fix Home title to "CircleCI Image Docs"

### DIFF
--- a/src/themes/example-1/layouts/index.html
+++ b/src/themes/example-1/layouts/index.html
@@ -1,4 +1,4 @@
-{{ define "title" }}Hugo Whisper Theme Demo{{ end}}
+{{ define "title" }}{{ .Site.Title }}{{ end}}
 {{ define "header_css" }}{{ end }}
 {{ define "body_classes" }}page-home{{ end }}
 {{ define "header_classes" }}{{ end }}


### PR DESCRIPTION
This is a cherry-pick of JugglerX/hugo-whisper-theme@459df15 by finferflu.

It fixes the title of [Home page](http://image-docs.circleci.io/) from "Hugo Whisper Theme Demo" to "CircleCI Image Docs".